### PR TITLE
Update Connection.php to fix type error

### DIFF
--- a/Transport/Connection.php
+++ b/Transport/Connection.php
@@ -162,7 +162,7 @@ class Connection implements ResetInterface
                 $query->getParameters(),
                 $query->getParameterTypes()
             );
-            $doctrineEnvelope = $stmt instanceof Result ? $stmt->fetchAssociative() : $stmt->fetch();
+            $doctrineEnvelope = $stmt->fetchAssociative();
 
             if (false === $doctrineEnvelope) {
                 $this->driverConnection->commit();


### PR DESCRIPTION
The `decodeEnvelopeHeaders()` call on line 177 is expecting an `array` type and sometimes it is being passed an object.

The database fetch on line 165 should always return an array.