### PR TITLE
Missing autosetup verification

### DIFF
--- a/Transport/Connection.php
+++ b/Transport/Connection.php
@@ -302,7 +302,9 @@ class Connection implements ResetInterface
             return;
         }
 
-        $this->addTableToSchema($schema);
+        if ($this->autoSetup) {
+            $this->addTableToSchema($schema);
+        }
     }
 
     /**


### PR DESCRIPTION
If I have created table messenger_messages myself in db migrations - I got schema validation error even if auto_setup is set to false. IMO this should be fixed by adding check for that.