### PR TITLE
WIP: Use common sequence name to get id from Oracle

### DIFF
--- a/Transport/Connection.php
+++ b/Transport/Connection.php
@@ -443,6 +443,18 @@ class Connection implements ResetInterface
                 if (!$id) {
                     throw new TransportException('no id was returned by PostgreSQL from RETURNING clause.');
                 }
+            } elseif ($this->driverConnection->getDatabasePlatform() instanceof OraclePlatform) {
+                $sequenceName = 'seq_' . $this->configuration['table_name'];
+
+                $this->driverConnection->executeStatement($sql, $parameters, $types);
+
+                $result = $this->driverConnection->fetchOne('SELECT ' . $sequenceName . '.CURRVAL FROM DUAL');
+
+                $id = (int) $result;
+
+                if (!$id) {
+                    throw new TransportException('no id was returned by Oracle from sequence: ' . $sequenceName);
+                }
             } else {
                 $this->driverConnection->executeStatement($sql, $parameters, $types);
 


### PR DESCRIPTION
This is a fix for https://github.com/symfony/symfony/issues/54193 by using a common sequence name for getting the ID's for Oracle databases.

This will require the user to name their sequences seq_<table_name> or SEQ_<TABLE_NAME> but at least allows you to use messenger with Oracle after properly setting up the table.